### PR TITLE
보고서 모듈에 consume, produce 로직 추가

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -60,3 +60,10 @@ IntelliJ에서 `docker-compose`로 실행 환경을 구성하는 방법은 다�
 
 ## 3. 테스트 방법 ✅
 todo
+
+
+## 4. 명령어 📂
+### 4-1. 카프카 Topic 목록 조회
+`/kafka-topics.sh --bootstrap-server localhost:9092 --list`
+### 4-2. 특정 Topic record 조회
+`./kafka-console-consumer --bootstrap-server localhost:9092 --topic {토픽명} --from-beginning`

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -64,6 +64,6 @@ todo
 
 ## 4. 명령어 📂
 ### 4-1. 카프카 Topic 목록 조회
-`/kafka-topics.sh --bootstrap-server localhost:9092 --list`
+`/kafka-topics --bootstrap-server localhost:9092 --list`
 ### 4-2. 특정 Topic record 조회
 `./kafka-console-consumer --bootstrap-server localhost:9092 --topic {토픽명} --from-beginning`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,9 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,INTERNAL://kafka:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1 # 토픽 오프셋 복제 계수
     ports:
       - "9092:9092"
@@ -25,7 +27,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     environment:
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9093
     depends_on: # kafka 실행 후 백엔드 실행되도록 설정
       - kafka
     networks:
@@ -39,7 +41,7 @@ services:
       context: ./report
       dockerfile: Dockerfile
     environment:
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9093
     depends_on: # kafka 실행 후 레포트 실행되도록 설정
       - kafka
     networks:

--- a/report/src/main/java/org/devpalsboot/report/controller/EventController.java
+++ b/report/src/main/java/org/devpalsboot/report/controller/EventController.java
@@ -1,0 +1,38 @@
+package org.devpalsboot.report.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.devpalsboot.report.service.ConsumerService;
+import org.devpalsboot.report.service.ProducerService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/event")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final ProducerService producerService;
+    private final ConsumerService consumerService;
+
+    /**
+     * 보고서 생성 완료 이벤트 produce
+     * @param message
+     * @return
+     */
+    @PostMapping("/report/completion")
+    public String sendReportCompletionEvent(@RequestParam("message") String message) {
+        producerService.sendReportCompletionEvent(message);
+        return "Message sent to Kafka: " + message;
+    }
+
+    /**
+     * 보고서 생성 요청 이벤트 consume
+     * @return
+     */
+    @GetMapping("/report/creation")
+    public List<String> consumeMessages() {
+        return consumerService.getMessages();
+    }
+
+}

--- a/report/src/main/java/org/devpalsboot/report/service/ConsumerService.java
+++ b/report/src/main/java/org/devpalsboot/report/service/ConsumerService.java
@@ -1,0 +1,25 @@
+package org.devpalsboot.report.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+public class ConsumerService {
+    public static final String REPORT_CREATION= "REPORT_CREATION";
+    private final List<String> messages = new ArrayList<>();
+
+    @KafkaListener(topics = REPORT_CREATION, groupId = "example-group")
+    public void listen(String message) {
+        messages.add(message);
+        log.info("Received message: " + message);
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+}

--- a/report/src/main/java/org/devpalsboot/report/service/ProducerService.java
+++ b/report/src/main/java/org/devpalsboot/report/service/ProducerService.java
@@ -1,0 +1,21 @@
+package org.devpalsboot.report.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProducerService {
+
+    public static final String REPORT_COMPLETE = "REPORT_COMPLETE";
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void sendReportCompletionEvent(String message) {
+        kafkaTemplate.send(REPORT_COMPLETE, message);
+        log.info("Report completion event sent: " + message);
+    }
+}

--- a/report/src/main/resources/application.yml
+++ b/report/src/main/resources/application.yml
@@ -1,5 +1,15 @@
 spring:
   application:
     name: report
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: my-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 server:
   port: 9090


### PR DESCRIPTION
추가된 API

1. 보고서 생성 완료 Topic produce 
`POST` `event/report/completion`
보고서 성생 완료 후 **REPORT_COMPLETE** 토픽을 발행하는 로직을 api에서 테스트 할 수 있도록 API 추가하였습니다.
해당 API를 사용하면, **REPORT_COMPLETE** 토픽이 카프카에 발행됩니다.
 
2. 보고서 생성 요청 Topic 목록 조회 
`GET` `event/report/creation`
보고서 서버가 Consume한 **REPORT_CREATION** 토픽의 record 목록을 조회할 수 있는 API 입니다.